### PR TITLE
Changed WatchedEvent and MultiTransactionRecord to support extending them

### DIFF
--- a/src/csharp/src/ZooKeeperNetEx/zookeeper/MultiTransactionRecord.cs
+++ b/src/csharp/src/ZooKeeperNetEx/zookeeper/MultiTransactionRecord.cs
@@ -30,7 +30,7 @@ namespace org.apache.zookeeper {
     /// the type of the following transaction or a negative number if no more transactions
     /// are included.
     /// </summary>
-    internal class MultiTransactionRecord : Record, IEnumerable<Op> {
+    public class MultiTransactionRecord : Record, IEnumerable<Op> {
         private readonly List<Op> ops;
 
         public MultiTransactionRecord() { ops=new List<Op>();}
@@ -43,7 +43,7 @@ namespace org.apache.zookeeper {
             return ops.GetEnumerator();
         }
 
-        internal void add(Op op) {
+        public void add(Op op) {
             ops.Add(op);
         }
 

--- a/src/csharp/src/ZooKeeperNetEx/zookeeper/WatchedEvent.cs
+++ b/src/csharp/src/ZooKeeperNetEx/zookeeper/WatchedEvent.cs
@@ -30,7 +30,7 @@ namespace org.apache.zookeeper
         private readonly Watcher.Event.EventType eventType;
         private readonly string path;
 
-        internal WatchedEvent(Watcher.Event.EventType eventType, Watcher.Event.KeeperState keeperState, string path) {
+        protected WatchedEvent(Watcher.Event.EventType eventType, Watcher.Event.KeeperState keeperState, string path) {
             this.keeperState = keeperState;
             this.eventType = eventType;
             this.path = path;
@@ -40,7 +40,7 @@ namespace org.apache.zookeeper
      * Convert a WatcherEvent sent over the wire into a full-fledged WatcherEvent
      */
 
-        internal WatchedEvent(WatcherEvent eventMessage) {
+        protected WatchedEvent(WatcherEvent eventMessage) {
             keeperState = EnumUtil<Watcher.Event.KeeperState>.DefinedCast(eventMessage.getState());
             eventType = EnumUtil<Watcher.Event.EventType>.DefinedCast(eventMessage.get_Type());
             path = eventMessage.getPath();


### PR DESCRIPTION
Need to be able to extend these classes, but MultiTransactionRecord was internal and WatchedEvent's constructors were also internal (the class was already public).  Made MultiTransactionRecord public and WatchEvent's constructors protected.