### PR TITLE
Remove "/" from node creation which now throws a NoNodeExpcetion

### DIFF
--- a/src/csharp/src/ZooKeeperNetEx.Recipes/leader/LeaderElectionSupport.cs
+++ b/src/csharp/src/ZooKeeperNetEx.Recipes/leader/LeaderElectionSupport.cs
@@ -224,7 +224,7 @@ namespace org.apache.zookeeper.recipes.leader {
             leaderOffer = new LeaderOffer();
 
             leaderOffer.HostName = HostName;
-            leaderOffer.NodePath = await ZooKeeper.createAsync(RootNodeName + "/" + "n_", HostName.UTF8getBytes(),
+            leaderOffer.NodePath = await ZooKeeper.createAsync(RootNodeName + "_", HostName.UTF8getBytes(),
                 ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL_SEQUENTIAL).ConfigureAwait(false);
 
             logger.debugFormat("Created leader offer {0}", leaderOffer);


### PR DESCRIPTION
I nocited when using ZooKeeper 3.5.5 a NoNodeException is thrown when creating one with a path containing a "/".
The starting "/" is still needed though.